### PR TITLE
Update HasRoles.php to remove strict return type binding

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -398,7 +398,7 @@ trait HasRoles
         return $this->roles->pluck('name');
     }
 
-    protected function getStoredRole($role): Role
+    protected function getStoredRole($role): static
     {
         if ($role instanceof \BackedEnum) {
             $role = $role->value;
@@ -412,7 +412,11 @@ trait HasRoles
             return $this->getRoleClass()::findByName($role, $this->getDefaultGuardName());
         }
 
-        return $role;
+        if ($role instanceof Role) {
+            return $role;
+        }
+
+        throw new \TypeError('Unsupported type');
     }
 
     protected function convertPipeToArray(string $pipeString)


### PR DESCRIPTION
There is a cases where developer creates model Role in app\models extending Role of the spatie to be able to add more fns. for example:

<?php

namespace App\Models;

use Spatie\Permission\Models\Role as SpatieRole;
use Illuminate\Database\Eloquent\Casts\Attribute;
use App\Enums\RolesEnum;
class Role extends SpatieRole
{
//fns you want model to have
}


In that scenario getStoredRole function returns error asking return type to be exactly Spatie\Permission\Models\Role. This patch fixes it.